### PR TITLE
Updated phpunit to dev and allowing multiple compatible versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,10 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "phpunit/phpunit": "3.7.18"
+        "ext-openssl": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~3 | ~4 | ~5"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Updated to allow phpunit to work with projects using 3, 4 or 5.

Also required ext-openssl, since it was mentioned as a requirement.